### PR TITLE
Wb7 patch poe

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,34 @@ Start the service.
 systemctl start pycdpd
 ```
 
+## Usage
+```
+usage: pycdpd [-h] [-i INTERFACE [INTERFACE ...]] [--interval [0-300]]
+              [-s SOFTWARE_VERSION] [-p PLATFORM] [-d DEVICEID] [-r REQUEST]
+              [--debug]
+
+Send CDP packages.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -i INTERFACE [INTERFACE ...], --interface INTERFACE [INTERFACE ...]
+                        interface to sende to packet out. (default: all)
+  --interval [0-300]    Interval in seconds. If greater than 0, packages will
+                        be sent until the program is terminated. (default: 60)
+  -s SOFTWARE_VERSION, --software-version SOFTWARE_VERSION
+                        Set the software-version string manually (default:
+                        autodetect)
+  -p PLATFORM, --platform PLATFORM
+                        Set the platform string manually (default: autodetect)
+  -d DEVICEID, --deviceid DEVICEID
+                        Set the device string manually (default: autodetect)
+  -r REQUEST, --request REQUEST
+                        Set the request id for PoE budget requests. Daemon
+                        will stop after sending PoE budget ACK for 20 Watts.
+                        Use it only with 802.3at midspan!
+  --debug               For debuging: print a message when a package is sent.
+  ```
+
 ## Examples
 
 ### Package in Wireshark

--- a/pycdpd
+++ b/pycdpd
@@ -5,6 +5,8 @@ This is a daemon to send out cdp packages.
 
 Copyright (C) 2020 Manuel Frei
 
+PoE budget extension for 802.3at devices by Lucas 'wb7' Garte
+
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
@@ -32,9 +34,9 @@ import subprocess
 from functools import lru_cache
 
 __author__ = "Manuel Frei"
-__credits__ = ["Manuel Frei"]
+__credits__ = ["Manuel Frei", "Lucas Garte"]
 __license__ = "GPLv3"
-__version__ = "0.1"
+__version__ = "0.2"
 __maintainer__ = "Manuel Frei"
 __email__ = "github@frei-style.net"
 __status__ = "Prototype"
@@ -391,7 +393,7 @@ class CDPPackage:
                  addresses="", port_id="", capabilities="", protocol_helo="",
                  vtp_management_domain="", native_vlan="", duplex="",
                  trust_bitmap="", untrusted_port_cos="",
-                 management_addresses="", power_available=""):
+                 management_addresses="", power_available="", request=""):
 
         self.device_id = device_id
         self.software_version = software_version
@@ -411,6 +413,8 @@ class CDPPackage:
         self.version = 2  # cdp version
         self.ttl = 180  # ttl in seconds, 0<= TTL <=255
         self.checksum = 0
+
+        self.request = request # request for poe
 
     def get_checksum(self):
         # https://tools.ietf.org/html/rfc791
@@ -450,6 +454,13 @@ class CDPPackage:
         ]
 
         bdata_list += [pack_data(field[0], field[1]) for field in fields]
+
+        if args.request:
+            request = self.request
+            request = hex(request).lstrip("0x").rstrip("L")
+            management = hex(12345).lstrip("0x").rstrip("L")
+            power = hex(20000).lstrip("0x").rstrip("L")
+            bdata_list += [struct.pack(f"!HH{8}s", CDPPackage.POWER_AVAILABLE, 12, bytes.fromhex(request) + bytes.fromhex(management) + bytes(2) + bytes.fromhex(power))]
 
         bdata = bytes().join(bdata_list)
 
@@ -504,6 +515,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "-r",
+        "--request",
+        type=int,
+        help="Set the request id for PoE budget requests. Daemon will stop after sending PoE budget ACK for 20 Watts. Use it only with 802.3at midspan!"
+    )
+
+    parser.add_argument(
         "--debug",
         action="store_true",
         help="For debuging: print a message when a package is sent."
@@ -534,6 +552,12 @@ if __name__ == "__main__":
     else:
         cdp_pkg.software_version = get_software_version()
 
+    if args.request:
+        cdp_pkg.request = args.request
+        killswitch = 1
+    else:
+        killswitch = 0
+
     # send CDP package in a loop
     while True:
 
@@ -560,6 +584,10 @@ if __name__ == "__main__":
             ethernet_package.send(interface)
             if args.debug:
                 print(f"CDP package sent on interface {interface}.")
+
+        # exit if request id is set
+        if killswitch == 1:
+            break
 
         # exit loop if interval is 0
         if args.interval == 0:


### PR DESCRIPTION
When using Cisco phones (like 8961) with non-Cisco and non-PoE switches, neither LLDP nor CDP can be used to get enough power (>15W) to satisfy the needs of a CKEM sidecar without an external powercube.

By adding a 802.3at ("PoE+") midspan, the phone can theoretically get 30 watts. That is enough for phone (8961) and sidecar (CKEM). Unfortunately, this only works if the CDP request for more power is answered. Without any answer to the power request from the phone, the phone stays at 802.3af ("normal" PoE) consumption.

When you boot up a Cisco phone, for example a 8961, it registers a consumption of 9,5 Watts. An additional sidecar needs 5 Watts more. To get this more power, the phone sends a CDP request:

```
[...]
    Power Request: 9503 mW, 15400 mW
        Type: Power Requested (0x0019)
        Length: 16
        Request-ID: 40219
        Management-ID: 0
        Power Requested: 9503mW
        Power Requested: 15400mW
[...]
```

This requests needs to be answered by pycdpd. I've added the parameter ```request```:

```
./pycdpd -r 40219
```

By executing it - or calling it from another python script, which detects these power requests - the following output is sent as part of the CDP package. Also the pycdpd is exiting afterwards, because normally this power budget snippet is only needed once on booting the phone.

```
[...]
    Power Available: 20000 mW
        Type: Power Available (0x001a)
        Length: 12
        Request-ID: 40219
        Management-ID: 12345
        Power Available: 20000mW
[...]
```

For now, it always sends an available power of 20 Watts. This is mostly enough to power to sidecars, but also not utilizing the whole budget.